### PR TITLE
Make whitespace between header and body configurable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+v2.5.0
+------
+*WIP:* _in progress_
+
+* Add BSD-3-Clause license support - thanks to Daniel Andrlik
+* Relicense from GPL 3.0 to Apache 2.0 in order to simplify use
+  in commercial environments
+* Configurable whitespace between license and file contents
+
 v2.4.4
 ------
 _18.03.2023_

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ A sample configuration is given below with each option annotated for explanation
   // specifies a custom title to put at the top of the file header.
   // Set to false or leave out to use the filename.
   "custom_title": false,
+  // controls the number of lines put after the license and before the rest of
+  // the file's contents. Defaults to the supported minimum of 1 if left out.
+  "lines_after_license": 1,
   // globbing expressions to specify files for which to maintain a license header
   // all expressions will be applied relative to the directory holding the config
   "include": [

--- a/test/package_lines_after_license.diff
+++ b/test/package_lines_after_license.diff
@@ -1,0 +1,13 @@
+diff --git a/code.cpp b/code.cpp
+index a1b8312..f1d8aa8 100644
+--- a/code.cpp
++++ b/code.cpp
+@@ -13,6 +13,8 @@
+  * WITHOUT WRITTEN PERMISSION OF UMBRELLA INC.
+  */
+ 
++
++
+ #include <iostream>
+ 
+ int main(int argc, char* argv[]){

--- a/test/package_lines_after_license.json
+++ b/test/package_lines_after_license.json
@@ -1,0 +1,7 @@
+{
+  "author": {
+    "name": "Test Author"
+  },
+  "license": "Proprietary",
+  "lines_after_license": 3
+}

--- a/test/package_lines_after_license.patch
+++ b/test/package_lines_after_license.patch
@@ -1,0 +1,39 @@
+From 5b43dbd60b2355884c3e5176c2c5f02ee93e6982 Mon Sep 17 00:00:00 2001
+From: Test Author <no-reply@unittest.local>
+Date: Wed, 26 Jan 2022 07:55:44 +0100
+Subject: [PATCH] Create main
+
+---
+ code.cpp | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 code.cpp
+
+diff --git a/code.cpp b/code.cpp
+new file mode 100644
+index 0000000..f53d6b0
+--- /dev/null
++++ b/code.cpp
+@@ -0,0 +1,21 @@
++/*
++ * code.cpp
++ *
++ * Copyright (c) 2022 Test Author
++ * All rights reserved.
++ *
++ * Unauthorized copying of this file, via any medium is strictly prohibited.
++ * This file is a proprietary and confidential part of a software product
++ * by Umbrella Inc or part of its connected software and documentation.
++ *
++ * ANY SOURCECODE BEARING THIS HEADER SHALL NOT BE RELEASED TO THE
++ * PUBLIC, BE USED, BE MODIFIED OR BE DISTRIBUTED IN ANY WAY
++ * WITHOUT WRITTEN PERMISSION OF UMBRELLA INC.
++ */
++
++#include <iostream>
++
++int main(int argc, char* argv[]){
++    std::cout << "Hello World" << std::endl;
++    return 0;
++}
+--
+2.34.1


### PR DESCRIPTION
Introduces a new configuration option for controlling the number of lines put between the license header and remaining body of a file.

Implements #1.