### PR TITLE
Fix parsing of empty files

### DIFF
--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -140,7 +140,7 @@ class Style(enum.Enum):
             (Style.POUND_STYLE,
                 r"#(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)# +@LICENSE_HEADER_END@(?:.*?)#\r?\n(?P<body>.*)"),
             (Style.POUND_STYLE,
-                r"#(?P<authors>.+?)All rights reserved\.(?P<license>.+?)#\r?\n(?P<body>[^#].*)"),
+                r"#(?P<authors>.+?)All rights reserved\.(?P<license>.+?)#\r?\n(?P<body>([^#].*)|$)"),
             (Style.DOCSTRING_STYLE,
                 r"\"\"\"\r?\n(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)@LICENSE_HEADER_END@(?:.*?)\r?\n\"\"\"(?P<body>.*)"),
             (Style.DOCSTRING_STYLE,
@@ -148,7 +148,7 @@ class Style(enum.Enum):
             (Style.DOCSTRING_STYLE,
                 r"#(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)# +@LICENSE_HEADER_END@(?:.*?)#\r?\n(?P<body>.*)"),
             (Style.DOCSTRING_STYLE,
-                r"#(?P<authors>.+?)All rights reserved\.(?P<license>.+?)#\r?\n(?P<body>[^#].*)"),
+                r"#(?P<authors>.+?)All rights reserved\.(?P<license>.+?)#\r?\n(?P<body>([^#].*)|$)"),
             (Style.XML_STYLE,
                 r"<!--\r?\n(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)@LICENSE_HEADER_END@(?:.*?)\r?\n-->(?P<body>.*)"),
             (Style.XML_STYLE,
@@ -564,7 +564,10 @@ class Tool:
         # the updated output is the new header with the remainder and ensuring a single trailing newline
         output = self.header.render(
             title, parsed.authors, parsed.style, company=self.company, license=license_text)
-        output = output + '\n' + parsed.remainder + '\n'
+        if parsed.remainder:
+            output = output + '\n' + parsed.remainder + '\n'
+        else:
+            output = output.strip() + '\n'
         if parsed.decls:
             output = '\n'.join(parsed.decls) + '\n' + output
         output = Tool.force_newline(output, parsed.newline)

--- a/test.py
+++ b/test.py
@@ -262,6 +262,17 @@ class TestParserPoundStyle(unittest.TestCase):
             "This library is"), parsed.license)
         self.assertEqual("import unittest", parsed.remainder)
 
+    @parser_test(BASE / 'test/TestParserPoundStyle-no_content.py')
+    def test_no_content(self, parsed):
+        self.assertEqual(1, len(parsed.authors))
+        self.assertEqual("Max Muster", parsed.authors[0].name)
+        self.assertEqual(2010, parsed.authors[0].year_from)
+        self.assertEqual(2010, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.DOCSTRING_STYLE, parsed.style)
+        self.assertTrue(parsed.license.startswith(
+            "This library is"), parsed.license)
+        self.assertEqual("", parsed.remainder)
+
     @parser_test(BASE / 'test/TestParserTaggedPoundStyle-1author_1year.cmake')
     def test_tagged_1author_1year(self, parsed):
         self.assertEqual(1, len(parsed.authors))

--- a/test/TestParserPoundStyle-no_content.py
+++ b/test/TestParserPoundStyle-no_content.py
@@ -1,0 +1,20 @@
+#
+# test.h
+#
+# Copyright (c) 2010 Max Muster
+# All rights reserved.
+#
+# This library is free software; you can redistribute it and/#r
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; #ither
+# version 2.1 of the License, or (at your option) any later #ersion.
+#
+# This library is distributed in the hope that it will be #seful,
+# but WITHOUT ANY WARRANTY; without even the implied #arranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See #he GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General #ublic
+# License along with this library; if not, write to the Free #oftware
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, #A  02110-1301  USA
+#

--- a/test/TestTool-bump_no_content.expected
+++ b/test/TestTool-bump_no_content.expected
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# TestTool-bump_no_content.input.py
+#
+# Copyright (c) 2021 Test Guy
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/test/TestTool-bump_no_content.input.py
+++ b/test/TestTool-bump_no_content.input.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# TestTool-bump_no_content.input.py
+#
+# Copyright (c) 2021 Test Guy
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
In some languages like python it may happen that a file is left intentionally empty, e.g. __init__.py to denote a module. This should still be well defined license header wise in that such files should end up with the header only.

Fixes #6 on Github.