### PR TITLE
Allow to override extension to comment style mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,17 @@ A sample configuration is given below with each option annotated for explanation
   // controls the number of lines put after the license and before the rest of
   // the file's contents. Defaults to the supported minimum of 1 if left out.
   "lines_after_license": 1,
+  // a dictionary to override the comment style used for a certain file extension
+  // Available comment styles is
+  //     C_STYLE -> /* ... */
+  //     POUND_STYLE -> # ...
+  //     DOCSTRING_STYLE -> """ ... """
+  //     XML_STYLE -> <!-- ... -->
+  //     BATCH_STYLE -> REM ...
+  //     SLASH_STYLE -> // ...
+  "style_for_suffix": {
+    ".cpp": "C_STYLE"
+  },
   // globbing expressions to specify files for which to maintain a license header
   // all expressions will be applied relative to the directory holding the config
   "include": [

--- a/test/package_custom_suffix_overrides.diff
+++ b/test/package_custom_suffix_overrides.diff
@@ -1,0 +1,13 @@
+diff --git a/code.cpp b/code.cpp
+index a1b8312..d811e21 100644
+--- a/code.cpp
++++ b/code.cpp
+@@ -1,3 +1,8 @@
++//
++// Copyright (c) 2022 Test Author
++// All rights reserved.
++//
++
+ /*
+  * code.cpp
+  *

--- a/test/package_custom_suffix_overrides.json
+++ b/test/package_custom_suffix_overrides.json
@@ -1,0 +1,11 @@
+{
+  "author": {
+    "name": "Test Author"
+  },
+  "license": false,
+  "title": false,
+  "style_for_suffix": {
+    ".cpp": "SLASH_STYLE",
+    ".hpp": "SLASH_STYLE"
+  }
+}

--- a/test/package_custom_suffix_overrides.patch
+++ b/test/package_custom_suffix_overrides.patch
@@ -1,0 +1,39 @@
+From 5b43dbd60b2355884c3e5176c2c5f02ee93e6982 Mon Sep 17 00:00:00 2001
+From: Test Author <no-reply@unittest.local>
+Date: Wed, 26 Jan 2022 07:55:44 +0100
+Subject: [PATCH] Create main
+
+---
+ code.cpp | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 code.cpp
+
+diff --git a/code.cpp b/code.cpp
+new file mode 100644
+index 0000000..f53d6b0
+--- /dev/null
++++ b/code.cpp
+@@ -0,0 +1,21 @@
++/*
++ * code.cpp
++ *
++ * Copyright (c) 2022 Test Author
++ * All rights reserved.
++ *
++ * Unauthorized copying of this file, via any medium is strictly prohibited.
++ * This file is a proprietary and confidential part of a software product
++ * by Umbrella Inc or part of its connected software and documentation.
++ *
++ * ANY SOURCECODE BEARING THIS HEADER SHALL NOT BE RELEASED TO THE
++ * PUBLIC, BE USED, BE MODIFIED OR BE DISTRIBUTED IN ANY WAY
++ * WITHOUT WRITTEN PERMISSION OF UMBRELLA INC.
++ */
++
++#include <iostream>
++
++int main(int argc, char* argv[]){
++    std::cout << "Hello World" << std::endl;
++    return 0;
++}
+--
+2.34.1


### PR DESCRIPTION
This allows for more flexibility when a different comment style is wanted or a file extension is not supported upstream yet

Closes #11