### PR TITLE
Fix header style detection after an override

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ A sample configuration is given below with each option annotated for explanation
   //     XML_STYLE -> <!-- ... -->
   //     BATCH_STYLE -> REM ...
   //     SLASH_STYLE -> // ...
-  "style_for_suffix": {
+  "style_override_for_suffix": {
     ".cpp": "C_STYLE"
   },
   // globbing expressions to specify files for which to maintain a license header

--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -775,7 +775,7 @@ def main():
             'title': f'<pick one of {", ".join(Title.BUILTINS)} or leave out>',
             'custom_title': False,
             'lines_after_license': 1,
-            'style_for_suffix': {
+            'style_override_for_suffix': {
                 ".cpp": f'<pick one of {", ".join([s.name for s in list(Style)])} or leave out>',
             },
             'include': [
@@ -895,8 +895,8 @@ def process_file(args, file) -> bool:
             logging.fatal(f"Invalid title '{title}' - supported titles are {valid}")
             sys.exit(2)
 
-    if 'style_for_suffix' in config:
-        Style.set_overrides(config['style_for_suffix'])
+    if 'style_override_for_suffix' in config:
+        Style.set_overrides(config['style_override_for_suffix'])
     else:
         Style.set_overrides(None)
 

--- a/test/package_custom_suffix_overrides.diff
+++ b/test/package_custom_suffix_overrides.diff
@@ -1,13 +1,34 @@
 diff --git a/code.cpp b/code.cpp
-index a1b8312..d811e21 100644
+index a1b8312..8011766 100644
 --- a/code.cpp
 +++ b/code.cpp
-@@ -1,3 +1,8 @@
+@@ -1,17 +1,15 @@
+-/*
+- * code.cpp
+- *
+- * Copyright (c) 2022 Test Author
+- * All rights reserved.
+- *
+- * Unauthorized copying of this file, via any medium is strictly prohibited.
+- * This file is a proprietary and confidential part of a software product
+- * by Umbrella Inc or part of its connected software and documentation.
+- *
+- * ANY SOURCECODE BEARING THIS HEADER SHALL NOT BE RELEASED TO THE
+- * PUBLIC, BE USED, BE MODIFIED OR BE DISTRIBUTED IN ANY WAY
+- * WITHOUT WRITTEN PERMISSION OF UMBRELLA INC.
+- */
 +//
 +// Copyright (c) 2022 Test Author
 +// All rights reserved.
 +//
-+
- /*
-  * code.cpp
-  *
++// Unauthorized copying of this file, via any medium is strictly prohibited.
++// This file is a proprietary and confidential part of a software product
++// by Umbrella Inc or part of its connected software and documentation.
++//
++// ANY SOURCECODE BEARING THIS HEADER SHALL NOT BE RELEASED TO THE
++// PUBLIC, BE USED, BE MODIFIED OR BE DISTRIBUTED IN ANY WAY
++// WITHOUT WRITTEN PERMISSION OF UMBRELLA INC.
++//
+ 
+ #include <iostream>
+ 

--- a/test/package_custom_suffix_overrides.json
+++ b/test/package_custom_suffix_overrides.json
@@ -4,7 +4,7 @@
   },
   "license": false,
   "title": false,
-  "style_for_suffix": {
+  "style_override_for_suffix": {
     ".cpp": "SLASH_STYLE",
     ".hpp": "SLASH_STYLE"
   }


### PR DESCRIPTION
Follow up to #11

Make sure to still detect the header style if it was overridden even if
it does not follow the override but the previous style