### PR TITLE
Make slash parser less greedy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: .+.diff$
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,12 +14,12 @@ repos:
     -   id: pretty-format-json
         args: [--autofix, --no-sort-keys, --no-ensure-ascii]
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: 'v1.5.7'
+    rev: 'v2.0.2'
     hooks:
     -   id: autopep8
         args: [--in-place, --max-line-length=120]
 -   repo: https://github.com/PyCQA/pylint
-    rev: 'v2.11.1'
+    rev: 'v3.0.0a6'
     hooks:
     -   id: pylint
 -   repo: local

--- a/.pylintrc
+++ b/.pylintrc
@@ -566,5 +566,5 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -170,7 +170,7 @@ class Style(enum.Enum):
             (Style.SLASH_STYLE,
                 r"//(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)// +@LICENSE_HEADER_END@(?:.*?)//\r?\n(?P<body>.*)"),
             (Style.SLASH_STYLE,
-                r"//(?P<authors>.+?)All rights reserved\.(?P<license>.+?)^(//)?\r?\n(?P<body>([^//].*)|$)"),
+                r"//(?P<authors>.+?)All rights reserved\.(?P<license>.+?)^(?P<body>[^/](.*)|$)"),
             (Style.UNKNOWN,
                 r"(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)@LICENSE_HEADER_END@(?P<body>.*)"),
         ]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ Setup description for license_tools.
 See README.md for detail and documentation.
 """
 
-from distutils.core import setup
+from distutils.core import setup  # pylint: disable=deprecated-module
 from subprocess import check_output, CalledProcessError
 import re
 import os

--- a/test.py
+++ b/test.py
@@ -557,6 +557,36 @@ class TestParserSlashStyle(unittest.TestCase):
         self.assertEqual(
             "#include <stdio.h>", parsed.remainder)
 
+    @parser_test(BASE / 'test/TestParserSlashStyle-comment_after_license.c')
+    def test_comment_after_license(self, parsed):
+        self.assertEqual(1, len(parsed.authors), str(parsed.authors))
+        self.assertEqual("Test Author", parsed.authors[0].name)
+        self.assertEqual(2022, parsed.authors[0].year_from)
+        self.assertEqual(2022, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.C_STYLE, parsed.style)
+        self.assertEqual(None, parsed.license)
+        self.assertTrue(parsed.remainder.startswith('// System'), parsed.remainder)
+
+    @parser_test(BASE / 'test/TestParserSlashStyle-no_newline_after_license.c')
+    def test_no_newline_after_license(self, parsed):
+        self.assertEqual(1, len(parsed.authors), str(parsed.authors))
+        self.assertEqual("Test Author", parsed.authors[0].name)
+        self.assertEqual(2022, parsed.authors[0].year_from)
+        self.assertEqual(2022, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.C_STYLE, parsed.style)
+        self.assertEqual(None, parsed.license)
+        self.assertTrue(parsed.remainder.startswith('#include'), parsed.remainder)
+
+    @parser_test(BASE / 'test/TestParserSlashStyle-no_newline_after_license_extra_slash.c')
+    def test_no_newline_after_license_extra_slash(self, parsed):
+        self.assertEqual(1, len(parsed.authors), str(parsed.authors))
+        self.assertEqual("Test Author", parsed.authors[0].name)
+        self.assertEqual(2022, parsed.authors[0].year_from)
+        self.assertEqual(2022, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.C_STYLE, parsed.style)
+        self.assertTrue(parsed.license.startswith('SPDX-License-Identifier:'), parsed.license)
+        self.assertTrue(parsed.remainder.startswith('#include'), parsed.remainder)
+
 
 class TestHeader(unittest.TestCase):
 

--- a/test/TestParserSlashStyle-comment_after_license.c
+++ b/test/TestParserSlashStyle-comment_after_license.c
@@ -1,0 +1,9 @@
+// Copyright (c) 2022 Test Author
+// All rights reserved.
+
+// System
+#include <stdlib.h>
+
+int main(){
+    return 0;
+}

--- a/test/TestParserSlashStyle-no_newline_after_license.c
+++ b/test/TestParserSlashStyle-no_newline_after_license.c
@@ -1,0 +1,7 @@
+// Copyright (c) 2022 Test Author
+// All rights reserved.
+#include <stdlib.h>
+
+int main(){
+    return 0;
+}

--- a/test/TestParserSlashStyle-no_newline_after_license_extra_slash.c
+++ b/test/TestParserSlashStyle-no_newline_after_license_extra_slash.c
@@ -1,0 +1,25 @@
+//
+// main.c
+//
+// Copyright (c) 2022 Test Author
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <stdlib.h>
+
+int main(){
+    return 0;
+}

--- a/test/package_comment_after_license.json
+++ b/test/package_comment_after_license.json
@@ -1,0 +1,11 @@
+{
+  "author": {
+    "name": "Test Author"
+  },
+  "license": false,
+  "title": false,
+  "style_override_for_suffix": {
+    ".cpp": "SLASH_STYLE",
+    ".hpp": "SLASH_STYLE"
+  }
+}

--- a/test/package_comment_after_license.patch
+++ b/test/package_comment_after_license.patch
@@ -1,0 +1,28 @@
+From 5b43dbd60b2355884c3e5176c2c5f02ee93e6982 Mon Sep 17 00:00:00 2001
+From: Test Author <no-reply@unittest.local>
+Date: Wed, 26 Jan 2022 07:55:44 +0100
+Subject: [PATCH] Create main
+
+---
+ code.cpp | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 code.cpp
+
+diff --git a/code.cpp b/code.cpp
+new file mode 100644
+index 0000000..f53d6b0
+--- /dev/null
++++ b/code.cpp
+@@ -0,0 +1,8 @@
++// Copyright (c) 2022 Test Author
++// All rights reserved.
++
++// STL
++#include <iostream>
++
++int main(int argc, char* argv[]){
++    std::cout << "Hello World" << std::endl;
++    return 0;
++}
+--
+2.34.1


### PR DESCRIPTION
Fix accidental inclusion of comments put with a blank line
right after the license header.

Closes #18 