### PR TITLE
Make pound parser less greedy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,14 @@
+v2.6.2
+------
+_24.09.2023_
+
+* Fix greedy parsing of pound-style comments after license header
+
 v2.6.1
 ------
 _14.07.2023_
 
-* Fix greedy parsing of comments after license header
+* Fix greedy parsing of slash-style comments after license header
 
 v2.6.0
 ------

--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -154,7 +154,7 @@ class Style(enum.Enum):
             (Style.DOCSTRING_STYLE,
                 r"#(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)# +@LICENSE_HEADER_END@(?:.*?)#\r?\n(?P<body>.*)"),
             (Style.DOCSTRING_STYLE,
-                r"#(?P<authors>.+?)All rights reserved\.(?P<license>.+?)^#?\r?\n(?P<body>([^#].*)|$)"),
+                r"#(?P<authors>.+?)All rights reserved\.(?P<license>.+?)^(?P<body>[^#](.*)|$)"),
             (Style.XML_STYLE,
                 r"<!--\r?\n(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)@LICENSE_HEADER_END@(?:.*?)\r?\n-->(?P<body>.*)"),
             (Style.XML_STYLE,

--- a/test.py
+++ b/test.py
@@ -567,6 +567,16 @@ class TestParserSlashStyle(unittest.TestCase):
         self.assertEqual(None, parsed.license)
         self.assertTrue(parsed.remainder.startswith('// System'), parsed.remainder)
 
+    @parser_test(BASE / 'test/TestParserPoundStyle-comment_after_license.py')
+    def test_comment_after_license(self, parsed):
+        self.assertEqual(1, len(parsed.authors), str(parsed.authors))
+        self.assertEqual("Test Author", parsed.authors[0].name)
+        self.assertEqual(2022, parsed.authors[0].year_from)
+        self.assertEqual(2022, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.DOCSTRING_STYLE, parsed.style)
+        self.assertEqual(None, parsed.license)
+        self.assertTrue(parsed.remainder.startswith('# System'), parsed.remainder)
+
     @parser_test(BASE / 'test/TestParserSlashStyle-no_newline_after_license.c')
     def test_no_newline_after_license(self, parsed):
         self.assertEqual(1, len(parsed.authors), str(parsed.authors))
@@ -577,6 +587,16 @@ class TestParserSlashStyle(unittest.TestCase):
         self.assertEqual(None, parsed.license)
         self.assertTrue(parsed.remainder.startswith('#include'), parsed.remainder)
 
+    @parser_test(BASE / 'test/TestParserPoundStyle-no_newline_after_license.py')
+    def test_no_newline_after_license(self, parsed):
+        self.assertEqual(1, len(parsed.authors), str(parsed.authors))
+        self.assertEqual("Test Author", parsed.authors[0].name)
+        self.assertEqual(2022, parsed.authors[0].year_from)
+        self.assertEqual(2022, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.DOCSTRING_STYLE, parsed.style)
+        self.assertEqual(None, parsed.license)
+        self.assertTrue(parsed.remainder.startswith('import sys'), parsed.remainder)
+
     @parser_test(BASE / 'test/TestParserSlashStyle-no_newline_after_license_extra_slash.c')
     def test_no_newline_after_license_extra_slash(self, parsed):
         self.assertEqual(1, len(parsed.authors), str(parsed.authors))
@@ -586,6 +606,16 @@ class TestParserSlashStyle(unittest.TestCase):
         self.assertEqual(license_tools.Style.C_STYLE, parsed.style)
         self.assertTrue(parsed.license.startswith('SPDX-License-Identifier:'), parsed.license)
         self.assertTrue(parsed.remainder.startswith('#include'), parsed.remainder)
+
+    @parser_test(BASE / 'test/TestParserPoundStyle-no_newline_after_license_extra_pound.py')
+    def test_no_newline_after_license_extra_slash(self, parsed):
+        self.assertEqual(1, len(parsed.authors), str(parsed.authors))
+        self.assertEqual("Test Author", parsed.authors[0].name)
+        self.assertEqual(2022, parsed.authors[0].year_from)
+        self.assertEqual(2022, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.DOCSTRING_STYLE, parsed.style)
+        self.assertTrue(parsed.license.startswith('SPDX-License-Identifier:'), parsed.license)
+        self.assertTrue(parsed.remainder.startswith('import sys'), parsed.remainder)
 
 
 class TestHeader(unittest.TestCase):

--- a/test/TestParserPoundStyle-comment_after_license.py
+++ b/test/TestParserPoundStyle-comment_after_license.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 Test Author
+# All rights reserved.
+
+# System packages
+import sys
+
+
+def main():
+    sys.exit(0)

--- a/test/TestParserPoundStyle-no_newline_after_license.py
+++ b/test/TestParserPoundStyle-no_newline_after_license.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Test Author
+# All rights reserved.
+import sys
+
+
+def main():
+    sys.exit(0)

--- a/test/TestParserPoundStyle-no_newline_after_license_extra_pound.py
+++ b/test/TestParserPoundStyle-no_newline_after_license_extra_pound.py
@@ -1,0 +1,25 @@
+#
+# main.py
+#
+# Copyright (c) 2022 Test Author
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+
+
+def main():
+    sys.exit(0)

--- a/test/package_comment_after_license2.json
+++ b/test/package_comment_after_license2.json
@@ -1,0 +1,7 @@
+{
+  "author": {
+    "name": "Test Author"
+  },
+  "license": false,
+  "title": false
+}

--- a/test/package_comment_after_license2.patch
+++ b/test/package_comment_after_license2.patch
@@ -1,0 +1,28 @@
+From 5b43dbd60b2355884c3e5176c2c5f02ee93e6982 Mon Sep 17 00:00:00 2001
+From: Test Author <no-reply@unittest.local>
+Date: Wed, 26 Jan 2022 07:55:44 +0100
+Subject: [PATCH] Create main
+
+---
+ code.py | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 code.py
+
+diff --git a/code.py b/code.py
+new file mode 100644
+index 0000000..f53d6b0
+--- /dev/null
++++ b/code.py
+@@ -0,0 +1,8 @@
++# Copyright (c) 2022 Test Author
++# All rights reserved.
++
++# system packages
++import sys
++
++def main():
++    print("Hello World")
++    sys.exit(0)
++
+--
+2.34.1


### PR DESCRIPTION
Fix accidental inclusion of comments put with a blank line
right after the license header

Closes #18