### PR TITLE
Fix handling of files with unicode BOM

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ _WIP_
 * Extend list of available SPDX licenses will all OSI approved licenses
   using headers as defined for the licenses
 * Make detection of comment style based on suffix case insensitive
+* Fix handling of files with unicode BOM
 
 v2.6.2
 ------

--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -1,6 +1,6 @@
 # __init__.py
 #
-# Copyright (c) 2012 - 2023 Marius Zwicker
+# Copyright (c) 2012 - 2024 Marius Zwicker
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -198,6 +198,8 @@ class Style(enum.Enum):
         Each entry is a pair of matching regex and additional flags required
         """
         return [
+            # unicode bom marker
+            (r'\uFEFF', 0),
             # something like '#!/usr/bin/env bash'
             (r'^#!.+', 0),
             # something like '# -*- coding: utf-8 -*-'

--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
 # test.py
 #
-# Copyright (c) 2021 - 2023 Marius Zwicker
+# Copyright (c) 2021 - 2024 Marius Zwicker
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -485,6 +485,21 @@ class TestParserXmlStyle(unittest.TestCase):
         self.assertTrue(parsed.license.startswith(
             "This library is"), parsed.license)
         self.assertEqual("<xml />", parsed.remainder)
+
+    @parser_test(BASE / 'test/TestParserXmlStyle-unicode_marker.xml')
+    def test_unicode_marker(self, parsed):
+        self.assertEqual(1, len(parsed.authors))
+        self.assertEqual("Max Muster", parsed.authors[0].name)
+        self.assertEqual(2010, parsed.authors[0].year_from)
+        self.assertEqual(2020, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.XML_STYLE, parsed.style)
+        self.assertListEqual(['\uFEFF', '<?xml version="1.0" encoding="utf-8"?>'], parsed.decls)
+        if '\r' in parsed.remainder:
+            self.assertEqual("<rcc>\r\n    <!-- qrc sample -->\r\n    <qresource", parsed.remainder[:46])
+        else:
+            self.assertEqual("<rcc>\n    <!-- qrc sample -->\n    <qresource", parsed.remainder[:44])
+        self.assertTrue(parsed.license.startswith(
+            "This library is"), parsed.license)
 
     @parser_test(BASE / 'test/TestParserXmlStyle-1author_2years.htm')
     def test_1author_2years(self, parsed):

--- a/test/TestParserXmlStyle-unicode_marker.xml
+++ b/test/TestParserXmlStyle-unicode_marker.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+ test.h
+
+ Copyright (c) 2010 - 2020 Max Muster
+ All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+
+<rcc>
+    <!-- qrc sample -->
+    <qresource prefix="/">
+    </qresource>
+</rcc>


### PR DESCRIPTION
Some files put a marker byte at the beginning of a file which should get treated as if a declaration

Closes #26.