### PR TITLE
Loosen strictness for whitespace handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+ v2.8.0
+ ------
+-_WIP_
+
+* Refactoring to get loc per file down to a manageable level again
+* Added option "ignore" to "lines_after_license" option to let other tools handle whitespace
+
 v2.7.0
 ------
 _09.01.2024_

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 * Refactoring to get loc per file down to a manageable level again
 * Added option "ignore" to "lines_after_license" option to let other tools handle whitespace
+* Fixed retention of mixed line endings in file
 
 v2.7.0
 ------

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ A sample configuration is given below with each option annotated for explanation
   "custom_title": false,
   // controls the number of lines put after the license and before the rest of
   // the file's contents. Defaults to the supported minimum of 1 if left out.
+  // Set to 'ignore' to not consider any changes in whitespace / lines at all,
+  // e.g. when those get corrected by a separate linter
   "lines_after_license": 1,
   // a dictionary to override the comment style used for a certain file extension
   // Available comment styles is

--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -132,12 +132,14 @@ class Tool:
         output = self.header.render(
             title=title_text, authors=parsed.authors, style=parsed.style, company=self.company, license=license_text)
         if parsed.remainder:
-            output = output + '\n' + parsed.remainder + '\n'
+            output = output + '\n'
         else:
             output = output.strip() + '\n'
         if parsed.decls:
             output = '\n'.join(parsed.decls) + '\n' + output
         output = TextUtils.force_newline(output, parsed.newline)
+        if parsed.remainder:
+            output = output + parsed.remainder + parsed.newline
 
         # compare old and new contents optionally ignoring any change in pure whitespace
         # so we play more nice with other linting tools

--- a/license_tools/__init__.py
+++ b/license_tools/__init__.py
@@ -31,7 +31,7 @@ from copy import copy
 from typing import Dict
 
 from .style import Style
-from .utils import DateUtils, FileFilter
+from .utils import DateUtils, FileFilter, TextUtils
 from .license import License, LICENSES
 from .git import GitRepo
 from .header import Header, ParsedHeader, Author, Title
@@ -52,17 +52,7 @@ class Tool:
         self.aliases = aliases or {}
         self.company = company
         self.header = Header(self.default_license, lines_after_license)
-
-    @staticmethod
-    def force_newline(input: str, newline='\n') -> str:
-        """Change input to use the given newline and return the result"""
-        if newline == '\n':
-            # fast path, simply drop any remaining dos endings
-            return input.replace('\r\n', '\n')
-        # this requires to sweep the input twice but is the most
-        # reliable way to catch all unix endings without the need
-        # to use a look-behind regex (which would be even slower)
-        return Tool.force_newline(input).replace('\n', newline)
+        self.ignore_whitespace = lines_after_license < 0
 
     def bump(self, filename: pathlib.PurePath,
              keep_license: bool = True, title: Title = None, keep_authors: bool = True, latest_year_only: bool = False) -> str:
@@ -147,7 +137,12 @@ class Tool:
             output = output.strip() + '\n'
         if parsed.decls:
             output = '\n'.join(parsed.decls) + '\n' + output
-        output = Tool.force_newline(output, parsed.newline)
+        output = TextUtils.force_newline(output, parsed.newline)
+
+        # compare old and new contents optionally ignoring any change in pure whitespace
+        # so we play more nice with other linting tools
+        if self.ignore_whitespace and not TextUtils.is_different_ignoring_ws(parsed.orig_contents, output):
+            return parsed.style, parsed.orig_contents
         return parsed.style, output
 
     def bump_inplace(self, filename: pathlib.PurePath, keep_license: bool = True,
@@ -397,9 +392,13 @@ def process_file(args, file) -> bool:
     aliases = config_author.get('aliases', {})
 
     try:
-        lines_after_license = int(config.get('lines_after_license', 1))
+        lines_after_license = config.get('lines_after_license', 1)
+        if 'ignore' == lines_after_license:
+            lines_after_license = -1
+        else:
+            lines_after_license = int(lines_after_license)
     except ValueError as error:
-        logging.fatal(f"Please provide the 'lines_after_license' attribute as integer: {error}")
+        logging.fatal(f"Please provide the 'lines_after_license' attribute as integer or use 'ignore': {error}")
         sys.exit(2)
 
     company = config_author.get('company', None)

--- a/license_tools/header.py
+++ b/license_tools/header.py
@@ -146,6 +146,8 @@ class ParsedHeader:
                 contents = file_obj.read()
         if isinstance(file, str):
             file = pathlib.Path(file)
+        # keep the original contents for book keeping
+        self.orig_contents = contents
         # style is determined from the extension, if unknown we try a second attempt using the contents below
         self.style = Style.from_suffix(file.suffix)
         if self.style == Style.UNKNOWN:

--- a/license_tools/utils.py
+++ b/license_tools/utils.py
@@ -175,3 +175,39 @@ class FileFilter:
                 break
         logging.debug(match_reason)
         return matched
+
+
+class TextUtils:
+    """Utilities for text functions used in this package"""
+
+    @staticmethod
+    def force_newline(input: str, newline='\n') -> str:
+        """Change input to use the given newline and return the result"""
+        if newline == '\n':
+            # fast path, simply drop any remaining dos endings
+            return input.replace('\r\n', '\n')
+        # this requires to sweep the input twice but is the most
+        # reliable way to catch all unix endings without the need
+        # to use a look-behind regex (which would be even slower)
+        return TextUtils.force_newline(input).replace('\n', newline)
+
+    @staticmethod
+    def is_different_ignoring_ws(lhs: str, rhs: str) -> bool:
+        """Compare two strings ignoring lines with no contents but whitespace"""
+        i = 0
+        j = 0
+        while i < len(lhs) and j < len(rhs):
+            line_lhs = lhs[i].strip()
+            if not line_lhs:
+                i += 1  # whitespace, skip
+                continue
+            line_rhs = rhs[j].strip()
+            if not line_rhs:
+                j += 1  # whitespace, skip
+                continue
+            if line_lhs != line_rhs:
+                print(f"'{line_lhs}' != '{line_rhs}'")
+                return True
+            i += 1
+            j += 1
+        return False

--- a/test/package/package_ignore_whitespace.json
+++ b/test/package/package_ignore_whitespace.json
@@ -1,0 +1,7 @@
+{
+  "author": {
+    "name": "Test Author"
+  },
+  "license": "Proprietary",
+  "lines_after_license": "ignore"
+}

--- a/test/package/package_ignore_whitespace.patch
+++ b/test/package/package_ignore_whitespace.patch
@@ -1,0 +1,43 @@
+From 5b43dbd60b2355884c3e5176c2c5f02ee93e6982 Mon Sep 17 00:00:00 2001
+From: Test Author <no-reply@unittest.local>
+Date: Wed, 26 Jan 2022 07:55:44 +0100
+Subject: [PATCH] Create main
+
+---
+ code.cpp | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 code.cpp
+
+diff --git a/code.cpp b/code.cpp
+new file mode 100644
+index 0000000..f53d6b0
+--- /dev/null
++++ b/code.cpp
+@@ -0,0 +1,21 @@
++/*
++ * code.cpp
++ *
++ * Copyright (c) 2022 Test Author
++ * All rights reserved.
++ *
++ * Unauthorized copying of this file, via any medium is strictly prohibited.
++ * This file is a proprietary and confidential part of a software product
++ * by Umbrella Inc or part of its connected software and documentation.
++ *
++ * ANY SOURCECODE BEARING THIS HEADER SHALL NOT BE RELEASED TO THE
++ * PUBLIC, BE USED, BE MODIFIED OR BE DISTRIBUTED IN ANY WAY
++ * WITHOUT WRITTEN PERMISSION OF UMBRELLA INC.
++ */
++
++
++
++
++
++#include <iostream>
++
++int main(int argc, char* argv[]){
++    std::cout << "Hello World" << std::endl;
++    return 0;
++}
+--
+2.34.1

--- a/test/test_text_utils.py
+++ b/test/test_text_utils.py
@@ -1,0 +1,55 @@
+# test.py
+#
+# Copyright (c) 2025 Marius Zwicker
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from license_tools.utils import TextUtils
+
+
+class TestTextUtils(unittest.TestCase):
+
+    def test_is_different_ignoring_ws(self):
+        VARIANT_A = """
+            one line
+
+            two line
+            three line
+        """
+        VARIANT_B = """
+            one line
+            two line
+            three line
+        """
+        VARIANT_C = """
+            one line
+               two line
+            three line
+        """
+        VARIANT_D = """
+            one line
+            .  two line
+            three line
+        """
+
+        self.assertFalse(TextUtils.is_different_ignoring_ws(VARIANT_A, VARIANT_A))
+        self.assertFalse(TextUtils.is_different_ignoring_ws(VARIANT_A, VARIANT_B))
+        self.assertFalse(TextUtils.is_different_ignoring_ws(VARIANT_A, VARIANT_C))
+
+        self.assertTrue(TextUtils.is_different_ignoring_ws(VARIANT_A, VARIANT_D))
+        self.assertTrue(TextUtils.is_different_ignoring_ws(VARIANT_B, VARIANT_D))
+        self.assertTrue(TextUtils.is_different_ignoring_ws(VARIANT_C, VARIANT_D))


### PR DESCRIPTION
Tweak logic for bumping files such that if the bumped file would only differ in whitespace we have an option to ignore it

Configuration is achieved by adding a special value to the 'lines_after_license' config option.

Closes #37 