### PR TITLE
Fix problems with urls when using SLASH_SYLE

### DIFF
--- a/license_tools/style.py
+++ b/license_tools/style.py
@@ -1,6 +1,7 @@
 # style.py
 #
 # Copyright (c) 2012 - 2025 Marius Zwicker
+# Copyright (c) 2025 François Bastien
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -199,7 +200,7 @@ class Style(enum.Enum):
         if style == Style.BATCH_STYLE:
             return Decorator(None, 'REM', None, r' ?(?:REM|::) ?')
         if style == Style.SLASH_STYLE:
-            return Decorator(None, '//', None, r' ?(?://) ?')
+            return Decorator(None, '//', None, r'^ ?(?://) ?')
         if style == Style.DASH_STYLE:
             return Decorator(None, '--', None, r' ?(?:--) ?')
         if style == Style.TRIPLE_SLASH_STYLE:

--- a/test/tool/TestTool-bump_keep_url.expected
+++ b/test/tool/TestTool-bump_keep_url.expected
@@ -1,0 +1,21 @@
+// TestTool-bump_keep_url.input.rs
+//
+// Copyright (c) 2021 Test Guy
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    println!("Hello World");
+}

--- a/test/tool/TestTool-bump_keep_url.input.rs
+++ b/test/tool/TestTool-bump_keep_url.input.rs
@@ -1,0 +1,21 @@
+// TestTool-bump_keep_url.input.rs
+//
+// Copyright (c) 2021 Test Guy
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>.
+
+fn main() {
+    println!("Hello World");
+}

--- a/test/tool/TestTool-bump_resource.expected
+++ b/test/tool/TestTool-bump_resource.expected
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http:www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/tool/TestTool-bump_resource_no_whitespace.expected
+++ b/test/tool/TestTool-bump_resource_no_whitespace.expected
@@ -7,7 +7,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http:www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
When using SLASH_STYLE, and the license header contains a header, and the header already contains the same license, if the license contains an url (eg, for `GPL-3.0-or-later`: `<https://www.gnu.org/licenses/>`) the `//` in the url is stripped.

For this case, I changed the pattern to be stripped from `r' ?(?://) ?'` to `r'^ ?(?://) ?'`.

In my case, it resolves the problem for my rust files.

I can't speak for other file types that uses SLASH_STYLE, maybe in some cases a second `//` on the same line ends the comment, and in this case it will need another fix, but for rust, it works.