### PR TITLE
Add Go text/template style, used by Helm

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+v2.9.0
+------
+_WIP_
+
+* Added support for Go text/template commenting style, used e.g. by Helm charts
+
 v2.8.0
 ------
 _21.08.2025_

--- a/license_tools/style.py
+++ b/license_tools/style.py
@@ -37,6 +37,7 @@ class Style(enum.Enum):
     SLASH_STYLE = 7
     DASH_STYLE = 8
     TRIPLE_SLASH_STYLE = 9
+    GO_TEXT_TEMPLATE_STYLE = 10
 
     @classmethod
     def set_overrides(cls, suffix_overrides=None):
@@ -79,7 +80,8 @@ class Style(enum.Enum):
             '.yaml': Style.POUND_STYLE,
             '.lua': Style.DASH_STYLE,
             '.rs': Style.SLASH_STYLE,
-            '.toml': Style.POUND_STYLE
+            '.toml': Style.POUND_STYLE,
+            '.tpl': Style.GO_TEXT_TEMPLATE_STYLE
         }
         suffix_overrides = getattr(cls, '__suffix_overrides', None)
         if suffix_overrides and ext in suffix_overrides:  # pylint: disable=unsupported-membership-test
@@ -145,6 +147,10 @@ class Style(enum.Enum):
                 r"//(?P<authors>.+?)All rights reserved\.(?P<license>.+?)^(?P<body>[^/](.*)|$)"),
             (Style.DASH_STYLE,
                 r"--(?P<authors>.+?)All rights reserved\.(?P<license>.+?)^(?P<body>[^-](.*)|$)"),
+            (Style.GO_TEXT_TEMPLATE_STYLE,
+                r"\{\{/\*\r?\n(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)@LICENSE_HEADER_END@(?:.*?)\r?\n\*/\}\}(?P<body>.*)"),
+            (Style.GO_TEXT_TEMPLATE_STYLE,
+                r"\{\{/\*\r?\n(?P<authors>.+?)All rights reserved\.(?P<license>.+?)\*/\}\}\r?\n(?P<body>.*)"),
             (Style.UNKNOWN,
                 r"(?P<authors>.+?)@LICENSE_HEADER_START@(?P<license>.+?)@LICENSE_HEADER_END@(?P<body>.*)"),
         ]
@@ -205,4 +211,6 @@ class Style(enum.Enum):
             return Decorator(None, '--', None, r' ?(?:--) ?')
         if style == Style.TRIPLE_SLASH_STYLE:
             return Decorator(None, '///', None, r' ?(?:///) ?')
+        if style == Style.GO_TEXT_TEMPLATE_STYLE:
+            return Decorator('{{/*', '', '*/}}', None)
         return Decorator('', '', '', None)

--- a/license_tools/style.py
+++ b/license_tools/style.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2012 - 2025 Marius Zwicker
 # Copyright (c) 2025 François Bastien
+# Copyright (c) 2025 Alberto Chiusole
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/test/generation/TestHeader-go_text_template_0BSD.expected
+++ b/test/generation/TestHeader-go_text_template_0BSD.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_0BSD.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: 0BSD
+
+ Licensed under the BSD Zero Clause License
+*/}}

--- a/test/generation/TestHeader-go_text_template_AAL.expected
+++ b/test/generation/TestHeader-go_text_template_AAL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_AAL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AAL
+
+ Licensed under the Attribution Assurance License
+*/}}

--- a/test/generation/TestHeader-go_text_template_AFL-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_AFL-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_AFL-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AFL-1.1
+
+ Licensed under the Academic Free License version 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_AFL-1.2.expected
+++ b/test/generation/TestHeader-go_text_template_AFL-1.2.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_AFL-1.2.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AFL-1.2
+
+ Licensed under the Academic Free License version 1.2
+*/}}

--- a/test/generation/TestHeader-go_text_template_AFL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_AFL-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_AFL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AFL-2.0
+
+ Licensed under the Academic Free License version 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_AFL-2.1.expected
+++ b/test/generation/TestHeader-go_text_template_AFL-2.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_AFL-2.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AFL-2.1
+
+ Licensed under the Academic Free License version 2.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_AFL-3.0.expected
+++ b/test/generation/TestHeader-go_text_template_AFL-3.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_AFL-3.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AFL-3.0
+
+ Licensed under the Academic Free License version 3.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_AGPL-3.0-only.expected
+++ b/test/generation/TestHeader-go_text_template_AGPL-3.0-only.expected
@@ -1,0 +1,22 @@
+{{/*
+ TestHeader-go_text_template_AGPL-3.0-only.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AGPL-3.0-only
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/}}

--- a/test/generation/TestHeader-go_text_template_AGPL-3.0-or-later.expected
+++ b/test/generation/TestHeader-go_text_template_AGPL-3.0-or-later.expected
@@ -1,0 +1,22 @@
+{{/*
+ TestHeader-go_text_template_AGPL-3.0-or-later.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: AGPL-3.0-or-later
+
+ This program is free software: you can redistribute it and/or modify it
+ under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or any
+ later version.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/}}

--- a/test/generation/TestHeader-go_text_template_APL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_APL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_APL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: APL-1.0
+
+ Licensed under the Adaptive Public License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_APSL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_APSL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_APSL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: APSL-1.0
+
+ Licensed under the Apple Public Source License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_APSL-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_APSL-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_APSL-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: APSL-1.1
+
+ Licensed under the Apple Public Source License 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_APSL-1.2.expected
+++ b/test/generation/TestHeader-go_text_template_APSL-1.2.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_APSL-1.2.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: APSL-1.2
+
+ Licensed under the Apple Public Source License 1.2
+*/}}

--- a/test/generation/TestHeader-go_text_template_APSL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_APSL-2.0.expected
@@ -1,0 +1,25 @@
+{{/*
+ TestHeader-go_text_template_APSL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: APSL-2.0
+
+ Portions Copyright (c) 1999-2007 Apple Inc. All Rights Reserved.
+ This file contains Original Code and/or Modifications of Original Code
+ as defined in and that are subject to the Apple Public Source License
+ Version 2.0 (the 'License'). You may not use this file except in
+ compliance with the License. Please obtain a copy of the License at
+ http://www.opensource.apple.com/apsl/ and read it before using this
+ file.
+
+ The Original Code and all software distributed under the License are
+ distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS
+ FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT. Please
+ see the License for the specific language governing rights and
+ limitations under the License.
+*/}}

--- a/test/generation/TestHeader-go_text_template_Apache-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_Apache-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Apache-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-1.1
+
+ Licensed under the Apache License 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_Apache-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_Apache-2.0.expected
@@ -1,0 +1,21 @@
+{{/*
+ TestHeader-go_text_template_Apache-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}

--- a/test/generation/TestHeader-go_text_template_Artistic-1.0-Perl.expected
+++ b/test/generation/TestHeader-go_text_template_Artistic-1.0-Perl.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Artistic-1.0-Perl.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Artistic-1.0-Perl
+
+ Licensed under the Artistic License 1.0 (Perl)
+*/}}

--- a/test/generation/TestHeader-go_text_template_Artistic-1.0-cl8.expected
+++ b/test/generation/TestHeader-go_text_template_Artistic-1.0-cl8.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Artistic-1.0-cl8.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Artistic-1.0-cl8
+
+ Licensed under the Artistic License 1.0 w/clause 8
+*/}}

--- a/test/generation/TestHeader-go_text_template_Artistic-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_Artistic-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Artistic-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Artistic-1.0
+
+ Licensed under the Artistic License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_Artistic-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_Artistic-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Artistic-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Artistic-2.0
+
+ Licensed under the Artistic License 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_BSD-1-Clause.expected
+++ b/test/generation/TestHeader-go_text_template_BSD-1-Clause.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_BSD-1-Clause.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BSD-1-Clause
+
+ Licensed under the BSD 1-Clause License
+*/}}

--- a/test/generation/TestHeader-go_text_template_BSD-2-Clause-Patent.expected
+++ b/test/generation/TestHeader-go_text_template_BSD-2-Clause-Patent.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_BSD-2-Clause-Patent.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BSD-2-Clause-Patent
+
+ Licensed under the BSD-2-Clause Plus Patent License
+*/}}

--- a/test/generation/TestHeader-go_text_template_BSD-2-Clause.expected
+++ b/test/generation/TestHeader-go_text_template_BSD-2-Clause.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_BSD-2-Clause.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BSD-2-Clause
+
+ Licensed under the BSD 2-Clause "Simplified" License
+*/}}

--- a/test/generation/TestHeader-go_text_template_BSD-3-Clause-LBNL.expected
+++ b/test/generation/TestHeader-go_text_template_BSD-3-Clause-LBNL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_BSD-3-Clause-LBNL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BSD-3-Clause-LBNL
+
+ Licensed under the Lawrence Berkeley National Labs BSD variant license
+*/}}

--- a/test/generation/TestHeader-go_text_template_BSD-3-Clause.expected
+++ b/test/generation/TestHeader-go_text_template_BSD-3-Clause.expected
@@ -1,0 +1,34 @@
+{{/*
+ TestHeader-go_text_template_BSD-3-Clause.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BSD-3-Clause
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/}}

--- a/test/generation/TestHeader-go_text_template_BSL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_BSL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_BSL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BSL-1.0
+
+ Licensed under the Boost Software License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_BlueOak-1.0.0.expected
+++ b/test/generation/TestHeader-go_text_template_BlueOak-1.0.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_BlueOak-1.0.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: BlueOak-1.0.0
+
+ Licensed under the Blue Oak Model License 1.0.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_CAL-1.0-Combined-Work-Exception.expected
+++ b/test/generation/TestHeader-go_text_template_CAL-1.0-Combined-Work-Exception.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CAL-1.0-Combined-Work-Exception.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CAL-1.0-Combined-Work-Exception
+
+ Licensed under the Cryptographic Autonomy License 1.0 (Combined Work Exception)
+*/}}

--- a/test/generation/TestHeader-go_text_template_CAL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_CAL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CAL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CAL-1.0
+
+ Licensed under the Cryptographic Autonomy License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_CATOSL-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_CATOSL-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CATOSL-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CATOSL-1.1
+
+ Licensed under the Computer Associates Trusted Open Source License 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_CDDL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_CDDL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CDDL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CDDL-1.0
+
+ Licensed under the Common Development and Distribution License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_CECILL-2.1.expected
+++ b/test/generation/TestHeader-go_text_template_CECILL-2.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CECILL-2.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CECILL-2.1
+
+ Licensed under the CeCILL Free Software License Agreement v2.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_CERN-OHL-P-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_CERN-OHL-P-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CERN-OHL-P-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CERN-OHL-P-2.0
+
+ Licensed under the CERN Open Hardware Licence Version 2 - Permissive
+*/}}

--- a/test/generation/TestHeader-go_text_template_CERN-OHL-S-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_CERN-OHL-S-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CERN-OHL-S-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CERN-OHL-S-2.0
+
+ Licensed under the CERN Open Hardware Licence Version 2 - Strongly Reciprocal
+*/}}

--- a/test/generation/TestHeader-go_text_template_CERN-OHL-W-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_CERN-OHL-W-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CERN-OHL-W-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CERN-OHL-W-2.0
+
+ Licensed under the CERN Open Hardware Licence Version 2 - Weakly Reciprocal
+*/}}

--- a/test/generation/TestHeader-go_text_template_CNRI-Python.expected
+++ b/test/generation/TestHeader-go_text_template_CNRI-Python.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CNRI-Python.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CNRI-Python
+
+ Licensed under the CNRI Python License
+*/}}

--- a/test/generation/TestHeader-go_text_template_CPL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_CPL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_CPL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: CPL-1.0
+
+ Licensed under the Common Public License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_ECL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_ECL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_ECL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: ECL-1.0
+
+ Licensed under the Educational Community License version 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_ECL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_ECL-2.0.expected
@@ -1,0 +1,21 @@
+{{/*
+ TestHeader-go_text_template_ECL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: ECL-2.0
+
+ Educational Community License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may
+ obtain a copy of the License at
+
+     http://www.osedu.org/licenses/ECL-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an "AS IS"
+ BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ or implied. See the License for the specific language governing
+ permissions and limitations under the License.
+*/}}

--- a/test/generation/TestHeader-go_text_template_EFL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_EFL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EFL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EFL-1.0
+
+ Licensed under the Eiffel Forum License v1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_EFL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_EFL-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EFL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EFL-2.0
+
+ Licensed under the Eiffel Forum License v2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_EPL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_EPL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EPL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EPL-1.0
+
+ Licensed under the Eclipse Public License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_EPL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_EPL-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EPL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EPL-2.0
+
+ Licensed under the Eclipse Public License 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_EUDatagrid.expected
+++ b/test/generation/TestHeader-go_text_template_EUDatagrid.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EUDatagrid.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EUDatagrid
+
+ Licensed under the EU DataGrid Software License
+*/}}

--- a/test/generation/TestHeader-go_text_template_EUPL-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_EUPL-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EUPL-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EUPL-1.1
+
+ Licensed under the European Union Public License 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_EUPL-1.2.expected
+++ b/test/generation/TestHeader-go_text_template_EUPL-1.2.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_EUPL-1.2.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: EUPL-1.2
+
+ Licensed under the European Union Public License 1.2
+*/}}

--- a/test/generation/TestHeader-go_text_template_Entessa.expected
+++ b/test/generation/TestHeader-go_text_template_Entessa.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Entessa.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Entessa
+
+ Licensed under the Entessa Public License v1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_Fair.expected
+++ b/test/generation/TestHeader-go_text_template_Fair.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Fair.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Fair
+
+ Licensed under the Fair License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Frameworx-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_Frameworx-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Frameworx-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Frameworx-1.0
+
+ Licensed under the Frameworx Open License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_GPL-2.0-only.expected
+++ b/test/generation/TestHeader-go_text_template_GPL-2.0-only.expected
@@ -1,0 +1,22 @@
+{{/*
+ TestHeader-go_text_template_GPL-2.0-only.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: GPL-2.0-only
+
+ This program is free software; you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the
+ Free Software Foundation; version 2.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/}}

--- a/test/generation/TestHeader-go_text_template_GPL-2.0-or-later.expected
+++ b/test/generation/TestHeader-go_text_template_GPL-2.0-or-later.expected
@@ -1,0 +1,23 @@
+{{/*
+ TestHeader-go_text_template_GPL-2.0-or-later.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: GPL-2.0-or-later
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Library General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/}}

--- a/test/generation/TestHeader-go_text_template_GPL-3.0-only.expected
+++ b/test/generation/TestHeader-go_text_template_GPL-3.0-only.expected
@@ -1,0 +1,21 @@
+{{/*
+ TestHeader-go_text_template_GPL-3.0-only.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: GPL-3.0-only
+
+ This program is free software: you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the
+ Free Software Foundation, version 3.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program. If not, see <https://www.gnu.org/licenses/>.
+*/}}

--- a/test/generation/TestHeader-go_text_template_GPL-3.0-or-later.expected
+++ b/test/generation/TestHeader-go_text_template_GPL-3.0-or-later.expected
@@ -1,0 +1,22 @@
+{{/*
+ TestHeader-go_text_template_GPL-3.0-or-later.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: GPL-3.0-or-later
+
+ This program is free software: you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or (at your
+ option) any later version.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program. If not, see <https://www.gnu.org/licenses/>.
+*/}}

--- a/test/generation/TestHeader-go_text_template_HPND.expected
+++ b/test/generation/TestHeader-go_text_template_HPND.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_HPND.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: HPND
+
+ Licensed under the Historical Permission Notice and Disclaimer
+*/}}

--- a/test/generation/TestHeader-go_text_template_ICU.expected
+++ b/test/generation/TestHeader-go_text_template_ICU.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_ICU.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: ICU
+
+ Licensed under the ICU License
+*/}}

--- a/test/generation/TestHeader-go_text_template_IPA.expected
+++ b/test/generation/TestHeader-go_text_template_IPA.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_IPA.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: IPA
+
+ Licensed under the IPA Font License
+*/}}

--- a/test/generation/TestHeader-go_text_template_IPL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_IPL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_IPL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: IPL-1.0
+
+ Licensed under the IBM Public License v1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_ISC.expected
+++ b/test/generation/TestHeader-go_text_template_ISC.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_ISC.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: ISC
+
+ Licensed under the ISC License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Intel.expected
+++ b/test/generation/TestHeader-go_text_template_Intel.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Intel.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Intel
+
+ Licensed under the Intel Open Source License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Jam.expected
+++ b/test/generation/TestHeader-go_text_template_Jam.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Jam.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Jam
+
+ Licensed under the Jam License
+*/}}

--- a/test/generation/TestHeader-go_text_template_LGPL-2.0-only.expected
+++ b/test/generation/TestHeader-go_text_template_LGPL-2.0-only.expected
@@ -1,0 +1,23 @@
+{{/*
+ TestHeader-go_text_template_LGPL-2.0-only.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LGPL-2.0-only
+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Library General Public License as published
+ by the Free Software Foundation; version 2.
+
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library
+ General Public License for more details.
+
+ You should have received a copy of the GNU Library General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301,
+ USA.
+*/}}

--- a/test/generation/TestHeader-go_text_template_LGPL-2.0-or-later.expected
+++ b/test/generation/TestHeader-go_text_template_LGPL-2.0-or-later.expected
@@ -1,0 +1,24 @@
+{{/*
+ TestHeader-go_text_template_LGPL-2.0-or-later.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LGPL-2.0-or-later
+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Library General Public License as published
+ by the Free Software Foundation; either version 2 of the License, or (at
+ your option) any later version.
+
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library
+ General Public License for more details.
+
+ You should have received a copy of the GNU Library General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301,
+ USA.
+*/}}

--- a/test/generation/TestHeader-go_text_template_LGPL-2.1-only.expected
+++ b/test/generation/TestHeader-go_text_template_LGPL-2.1-only.expected
@@ -1,0 +1,22 @@
+{{/*
+ TestHeader-go_text_template_LGPL-2.1-only.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LGPL-2.1-only
+
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation; version 2.1.
+
+ This library is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+ General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/}}

--- a/test/generation/TestHeader-go_text_template_LGPL-2.1-or-later.expected
+++ b/test/generation/TestHeader-go_text_template_LGPL-2.1-or-later.expected
@@ -1,0 +1,23 @@
+{{/*
+ TestHeader-go_text_template_LGPL-2.1-or-later.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LGPL-2.1-or-later
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/}}

--- a/test/generation/TestHeader-go_text_template_LGPL-3.0-only.expected
+++ b/test/generation/TestHeader-go_text_template_LGPL-3.0-only.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LGPL-3.0-only.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LGPL-3.0-only
+
+ Licensed under the GNU Lesser General Public License v3.0 only
+*/}}

--- a/test/generation/TestHeader-go_text_template_LGPL-3.0-or-later.expected
+++ b/test/generation/TestHeader-go_text_template_LGPL-3.0-or-later.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LGPL-3.0-or-later.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LGPL-3.0-or-later
+
+ Licensed under the GNU Lesser General Public License v3.0 or later
+*/}}

--- a/test/generation/TestHeader-go_text_template_LPL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_LPL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LPL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LPL-1.0
+
+ Licensed under the Lucent Public License Version 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_LPL-1.02.expected
+++ b/test/generation/TestHeader-go_text_template_LPL-1.02.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LPL-1.02.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LPL-1.02
+
+ Licensed under the Lucent Public License v1.02
+*/}}

--- a/test/generation/TestHeader-go_text_template_LiLiQ-P-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_LiLiQ-P-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LiLiQ-P-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LiLiQ-P-1.1
+
+ Licensed under the Licence Libre du Québec – Permissive version 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_LiLiQ-R-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_LiLiQ-R-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LiLiQ-R-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LiLiQ-R-1.1
+
+ Licensed under the Licence Libre du Québec – Réciprocité version 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_LiLiQ-Rplus-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_LiLiQ-Rplus-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_LiLiQ-Rplus-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: LiLiQ-Rplus-1.1
+
+ Licensed under the Licence Libre du Québec – Réciprocité forte version 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_MIT-0.expected
+++ b/test/generation/TestHeader-go_text_template_MIT-0.expected
@@ -1,0 +1,24 @@
+{{/*
+ TestHeader-go_text_template_MIT-0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MIT-0
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ OR OTHER DEALINGS IN THE SOFTWARE.
+*/}}

--- a/test/generation/TestHeader-go_text_template_MIT-Modern-Variant.expected
+++ b/test/generation/TestHeader-go_text_template_MIT-Modern-Variant.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_MIT-Modern-Variant.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MIT-Modern-Variant
+
+ Licensed under the MIT License Modern Variant
+*/}}

--- a/test/generation/TestHeader-go_text_template_MIT.expected
+++ b/test/generation/TestHeader-go_text_template_MIT.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_MIT.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MIT
+
+ Licensed under the MIT License
+*/}}

--- a/test/generation/TestHeader-go_text_template_MPL-2.0-no-copyleft-exception.expected
+++ b/test/generation/TestHeader-go_text_template_MPL-2.0-no-copyleft-exception.expected
@@ -1,0 +1,16 @@
+{{/*
+ TestHeader-go_text_template_MPL-2.0-no-copyleft-exception.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MPL-2.0-no-copyleft-exception
+
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ This Source Code Form is "Incompatible With Secondary Licenses", as
+ defined by the Mozilla Public License, v. 2.0.
+*/}}

--- a/test/generation/TestHeader-go_text_template_MPL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_MPL-2.0.expected
@@ -1,0 +1,13 @@
+{{/*
+ TestHeader-go_text_template_MPL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MPL-2.0
+
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/}}

--- a/test/generation/TestHeader-go_text_template_MS-PL.expected
+++ b/test/generation/TestHeader-go_text_template_MS-PL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_MS-PL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MS-PL
+
+ Licensed under the Microsoft Public License
+*/}}

--- a/test/generation/TestHeader-go_text_template_MS-RL.expected
+++ b/test/generation/TestHeader-go_text_template_MS-RL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_MS-RL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MS-RL
+
+ Licensed under the Microsoft Reciprocal License
+*/}}

--- a/test/generation/TestHeader-go_text_template_MirOS.expected
+++ b/test/generation/TestHeader-go_text_template_MirOS.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_MirOS.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: MirOS
+
+ Licensed under the The MirOS Licence
+*/}}

--- a/test/generation/TestHeader-go_text_template_Motosoto.expected
+++ b/test/generation/TestHeader-go_text_template_Motosoto.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Motosoto.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Motosoto
+
+ Licensed under the Motosoto License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Multics.expected
+++ b/test/generation/TestHeader-go_text_template_Multics.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Multics.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Multics
+
+ Licensed under the Multics License
+*/}}

--- a/test/generation/TestHeader-go_text_template_NASA-1.3.expected
+++ b/test/generation/TestHeader-go_text_template_NASA-1.3.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_NASA-1.3.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: NASA-1.3
+
+ Licensed under the NASA Open Source Agreement 1.3
+*/}}

--- a/test/generation/TestHeader-go_text_template_NCSA.expected
+++ b/test/generation/TestHeader-go_text_template_NCSA.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_NCSA.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: NCSA
+
+ Licensed under the University of Illinois/NCSA Open Source License
+*/}}

--- a/test/generation/TestHeader-go_text_template_NGPL.expected
+++ b/test/generation/TestHeader-go_text_template_NGPL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_NGPL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: NGPL
+
+ Licensed under the Nethack General Public License
+*/}}

--- a/test/generation/TestHeader-go_text_template_NPOSL-3.0.expected
+++ b/test/generation/TestHeader-go_text_template_NPOSL-3.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_NPOSL-3.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: NPOSL-3.0
+
+ Licensed under the Non-Profit Open Software License 3.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_NTP.expected
+++ b/test/generation/TestHeader-go_text_template_NTP.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_NTP.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: NTP
+
+ Licensed under the NTP License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Naumen.expected
+++ b/test/generation/TestHeader-go_text_template_Naumen.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Naumen.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Naumen
+
+ Licensed under the Naumen Public License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Nokia.expected
+++ b/test/generation/TestHeader-go_text_template_Nokia.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Nokia.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Nokia
+
+ Licensed under the Nokia Open Source License
+*/}}

--- a/test/generation/TestHeader-go_text_template_OFL-1.1-RFN.expected
+++ b/test/generation/TestHeader-go_text_template_OFL-1.1-RFN.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OFL-1.1-RFN.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OFL-1.1-RFN
+
+ Licensed under the SIL Open Font License 1.1 with Reserved Font Name
+*/}}

--- a/test/generation/TestHeader-go_text_template_OFL-1.1-no-RFN.expected
+++ b/test/generation/TestHeader-go_text_template_OFL-1.1-no-RFN.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OFL-1.1-no-RFN.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OFL-1.1-no-RFN
+
+ Licensed under the SIL Open Font License 1.1 with no Reserved Font Name
+*/}}

--- a/test/generation/TestHeader-go_text_template_OFL-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_OFL-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OFL-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OFL-1.1
+
+ Licensed under the SIL Open Font License 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_OGTSL.expected
+++ b/test/generation/TestHeader-go_text_template_OGTSL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OGTSL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OGTSL
+
+ Licensed under the Open Group Test Suite License
+*/}}

--- a/test/generation/TestHeader-go_text_template_OLDAP-2.8.expected
+++ b/test/generation/TestHeader-go_text_template_OLDAP-2.8.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OLDAP-2.8.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OLDAP-2.8
+
+ Licensed under the Open LDAP Public License v2.8
+*/}}

--- a/test/generation/TestHeader-go_text_template_OLFL-1.3.expected
+++ b/test/generation/TestHeader-go_text_template_OLFL-1.3.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OLFL-1.3.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OLFL-1.3
+
+ Licensed under the Open Logistics Foundation License Version 1.3
+*/}}

--- a/test/generation/TestHeader-go_text_template_OSET-PL-2.1.expected
+++ b/test/generation/TestHeader-go_text_template_OSET-PL-2.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OSET-PL-2.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OSET-PL-2.1
+
+ Licensed under the OSET Public License version 2.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_OSL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_OSL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OSL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OSL-1.0
+
+ Licensed under the Open Software License version 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_OSL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_OSL-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OSL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OSL-2.0
+
+ Licensed under the Open Software License version 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_OSL-2.1.expected
+++ b/test/generation/TestHeader-go_text_template_OSL-2.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OSL-2.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OSL-2.1
+
+ Licensed under the Open Software License version 2.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_OSL-3.0.expected
+++ b/test/generation/TestHeader-go_text_template_OSL-3.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_OSL-3.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: OSL-3.0
+
+ Licensed under the Open Software License version 3.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_PHP-3.0.expected
+++ b/test/generation/TestHeader-go_text_template_PHP-3.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_PHP-3.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: PHP-3.0
+
+ Licensed under the PHP License v3.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_PHP-3.01.expected
+++ b/test/generation/TestHeader-go_text_template_PHP-3.01.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_PHP-3.01.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: PHP-3.01
+
+ Licensed under the PHP License v3.01
+*/}}

--- a/test/generation/TestHeader-go_text_template_PostgreSQL.expected
+++ b/test/generation/TestHeader-go_text_template_PostgreSQL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_PostgreSQL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: PostgreSQL
+
+ Licensed under the PostgreSQL License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Proprietary.expected
+++ b/test/generation/TestHeader-go_text_template_Proprietary.expected
@@ -1,0 +1,15 @@
+{{/*
+ TestHeader-go_text_template_Proprietary.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ Unauthorized copying of this file, via any medium is strictly prohibited.
+ This file is a proprietary and confidential part of a software product
+ by the authors or part of its connected software and documentation.
+
+ ANY FILE BEARING THIS HEADER SHALL NOT BE RELEASED TO THE
+ PUBLIC, BE USED, BE MODIFIED OR BE DISTRIBUTED IN ANY WAY
+ WITHOUT WRITTEN PERMISSION OF THE AUTHORS.
+*/}}

--- a/test/generation/TestHeader-go_text_template_Python-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_Python-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Python-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Python-2.0
+
+ Licensed under the Python License 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_QPL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_QPL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_QPL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: QPL-1.0
+
+ Licensed under the Q Public License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_RPL-1.1.expected
+++ b/test/generation/TestHeader-go_text_template_RPL-1.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_RPL-1.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: RPL-1.1
+
+ Licensed under the Reciprocal Public License 1.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_RPL-1.5.expected
+++ b/test/generation/TestHeader-go_text_template_RPL-1.5.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_RPL-1.5.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: RPL-1.5
+
+ Licensed under the Reciprocal Public License 1.5
+*/}}

--- a/test/generation/TestHeader-go_text_template_RSCPL.expected
+++ b/test/generation/TestHeader-go_text_template_RSCPL.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_RSCPL.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: RSCPL
+
+ Licensed under the Ricoh Source Code Public License
+*/}}

--- a/test/generation/TestHeader-go_text_template_SimPL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_SimPL-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_SimPL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: SimPL-2.0
+
+ Licensed under the Simple Public License 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_Sleepycat.expected
+++ b/test/generation/TestHeader-go_text_template_Sleepycat.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Sleepycat.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Sleepycat
+
+ Licensed under the Sleepycat License
+*/}}

--- a/test/generation/TestHeader-go_text_template_UCL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_UCL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_UCL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: UCL-1.0
+
+ Licensed under the Upstream Compatibility License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_UPL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_UPL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_UPL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: UPL-1.0
+
+ Licensed under the Universal Permissive License v1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_Unicode-3.0.expected
+++ b/test/generation/TestHeader-go_text_template_Unicode-3.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Unicode-3.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Unicode-3.0
+
+ Licensed under the Unicode License v3
+*/}}

--- a/test/generation/TestHeader-go_text_template_Unicode-DFS-2016.expected
+++ b/test/generation/TestHeader-go_text_template_Unicode-DFS-2016.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Unicode-DFS-2016.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Unicode-DFS-2016
+
+ Licensed under the Unicode License Agreement - Data Files and Software (2016)
+*/}}

--- a/test/generation/TestHeader-go_text_template_Unlicense.expected
+++ b/test/generation/TestHeader-go_text_template_Unlicense.expected
@@ -1,0 +1,32 @@
+{{/*
+ TestHeader-go_text_template_Unlicense.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Unlicense
+
+ This is free and unencumbered software released into the public domain.
+
+ Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+ this software, either in source code form or as a compiled binary, for any
+ purpose, commercial or non-commercial, and by any means.
+
+ In jurisdictions that recognize copyright laws, the author or authors of
+ this software dedicate any and all copyright interest in the software to
+ the public domain. We make this dedication for the benefit of the public
+ at large and to the detriment of our heirs and successors. We intend this
+ dedication to be an overt act of relinquishment in perpetuity of all
+ present and future rights to this software under copyright law.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE.
+
+ For more information, please refer to <https://unlicense.org/>
+*/}}

--- a/test/generation/TestHeader-go_text_template_VSL-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_VSL-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_VSL-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: VSL-1.0
+
+ Licensed under the Vovida Software License v1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_W3C.expected
+++ b/test/generation/TestHeader-go_text_template_W3C.expected
@@ -1,0 +1,13 @@
+{{/*
+ TestHeader-go_text_template_W3C.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: W3C
+
+ This work is distributed under the W3C® Software License in the hope
+ that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*/}}

--- a/test/generation/TestHeader-go_text_template_Watcom-1.0.expected
+++ b/test/generation/TestHeader-go_text_template_Watcom-1.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Watcom-1.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Watcom-1.0
+
+ Licensed under the Sybase Open Watcom Public License 1.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_WordNet.expected
+++ b/test/generation/TestHeader-go_text_template_WordNet.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_WordNet.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: WordNet
+
+ Licensed under the WordNet License
+*/}}

--- a/test/generation/TestHeader-go_text_template_Xnet.expected
+++ b/test/generation/TestHeader-go_text_template_Xnet.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Xnet.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Xnet
+
+ Licensed under the X.Net License
+*/}}

--- a/test/generation/TestHeader-go_text_template_ZPL-2.0.expected
+++ b/test/generation/TestHeader-go_text_template_ZPL-2.0.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_ZPL-2.0.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: ZPL-2.0
+
+ Licensed under the Zope Public License 2.0
+*/}}

--- a/test/generation/TestHeader-go_text_template_ZPL-2.1.expected
+++ b/test/generation/TestHeader-go_text_template_ZPL-2.1.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_ZPL-2.1.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: ZPL-2.1
+
+ Licensed under the Zope Public License 2.1
+*/}}

--- a/test/generation/TestHeader-go_text_template_Zlib.expected
+++ b/test/generation/TestHeader-go_text_template_Zlib.expected
@@ -1,0 +1,11 @@
+{{/*
+ TestHeader-go_text_template_Zlib.expected
+
+ Copyright (c) 2013 - 2020 Max Muster
+ Copyright (c) 2021 Umbrella Inc
+ All rights reserved.
+
+ SPDX-License-Identifier: Zlib
+
+ Licensed under the zlib License
+*/}}

--- a/test/parser/TestParserGoTextTemplateStyle-1author_1year.tpl
+++ b/test/parser/TestParserGoTextTemplateStyle-1author_1year.tpl
@@ -1,0 +1,24 @@
+{{/*
+ test.tpl
+
+ Copyright (c) 2010 Max Muster
+ All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/}}
+
+{{ define "main" }}
+<h1>{{ .Title }}</h1>
+{{ end }}

--- a/test/parser/TestParserGoTextTemplateStyle-1author_2years.tpl
+++ b/test/parser/TestParserGoTextTemplateStyle-1author_2years.tpl
@@ -1,0 +1,24 @@
+{{/*
+ test.tpl
+
+ Copyright (c) 2010-2013 Max Muster
+ All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/}}
+
+{{ define "main" }}
+<h1>{{ .Title }}</h1>
+{{ end }}

--- a/test/parser/TestParserGoTextTemplateStyle-2authors_2years.tpl
+++ b/test/parser/TestParserGoTextTemplateStyle-2authors_2years.tpl
@@ -1,0 +1,25 @@
+{{/*
+ test.tpl
+
+ Copyright (c) 2010-2013 Max Muster
+ Copyright (c) 2013-2016 Susi Sorglos
+ All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/}}
+
+{{ define "main" }}
+<h1>{{ .Title }}</h1>
+{{ end }}

--- a/test/test_header.py
+++ b/test/test_header.py
@@ -48,6 +48,7 @@ class TestHeader(unittest.TestCase):
                     license_tools.Style.SLASH_STYLE: f'TestHeader-slash_{l}.expected',
                     license_tools.Style.DASH_STYLE: f'TestHeader-dash_{l}.expected',
                     license_tools.Style.TRIPLE_SLASH_STYLE: f'TestHeader-triple_slash_{l}.expected',
+                    license_tools.Style.GO_TEXT_TEMPLATE_STYLE: f'TestHeader-go_text_template_{l}.expected',
                 }
                 filename = candidates[style]
                 output = header.render(

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -647,3 +647,42 @@ class TestParserDashStyle(unittest.TestCase):
         self.assertEqual(license_tools.Style.DASH_STYLE, parsed.style)
         self.assertTrue(parsed.license.startswith('SPDX-License-Identifier:'), parsed.license)
         self.assertTrue(parsed.remainder.startswith('print'), parsed.remainder)
+
+
+class TestParserGoTextTemplateStyle(unittest.TestCase):
+
+    @parser_test(BASE / 'test/parser/TestParserGoTextTemplateStyle-1author_1year.tpl')
+    def test_1author_1year(self, parsed):
+        self.assertEqual(1, len(parsed.authors))
+        self.assertEqual("Max Muster", parsed.authors[0].name)
+        self.assertEqual(2010, parsed.authors[0].year_from)
+        self.assertEqual(2010, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.GO_TEXT_TEMPLATE_STYLE, parsed.style)
+        self.assertTrue(parsed.license.startswith(
+            "This library is"), parsed.license)
+        self.assertTrue(parsed.remainder.startswith('{{ define'), parsed.remainder)
+
+    @parser_test(BASE / 'test/parser/TestParserGoTextTemplateStyle-1author_2years.tpl')
+    def test_1author_2years(self, parsed):
+        self.assertEqual(1, len(parsed.authors))
+        self.assertEqual("Max Muster", parsed.authors[0].name)
+        self.assertEqual(2010, parsed.authors[0].year_from)
+        self.assertEqual(2013, parsed.authors[0].year_to)
+        self.assertEqual(license_tools.Style.GO_TEXT_TEMPLATE_STYLE, parsed.style)
+        self.assertTrue(parsed.license.startswith(
+            "This library is"), parsed.license)
+        self.assertTrue(parsed.remainder.startswith('{{ define'), parsed.remainder)
+
+    @parser_test(BASE / 'test/parser/TestParserGoTextTemplateStyle-2authors_2years.tpl')
+    def test_2authors_2years(self, parsed):
+        self.assertEqual(2, len(parsed.authors))
+        self.assertEqual("Max Muster", parsed.authors[0].name)
+        self.assertEqual(2010, parsed.authors[0].year_from)
+        self.assertEqual(2013, parsed.authors[0].year_to)
+        self.assertEqual("Susi Sorglos", parsed.authors[1].name)
+        self.assertEqual(2013, parsed.authors[1].year_from)
+        self.assertEqual(2016, parsed.authors[1].year_to)
+        self.assertEqual(license_tools.Style.GO_TEXT_TEMPLATE_STYLE, parsed.style)
+        self.assertTrue(parsed.license.startswith(
+            "This library is"), parsed.license)
+        self.assertTrue(parsed.remainder.startswith('{{ define'), parsed.remainder)


### PR DESCRIPTION
Hi, thanks for this project!
I've found it thanks to the pre-commit hook example, and I've been using it to apply licensing headers to Helm chart templates.

I noticed that it was missing the [Go text/template style](https://pkg.go.dev/text/template), used in [Helm files](https://helm.sh/docs/chart_best_practices/templates/#comments-yaml-comments-vs-template-comments), so I added support for it with all the supporting testing files.
I have to explicitly tell `lictool` to use it on `.yaml` files, otherwise it would use the default pound style with a config similar to the following:
```json5
{
  // other params here
  "style_override_for_suffix": {
    ".yaml": "GO_TEXT_TEMPLATE_STYLE",
    ".txt": "GO_TEXT_TEMPLATE_STYLE"
  },
  "include": [
    "*/templates/*.tpl",
    "*/templates/*.txt",
    "*/templates/*.yaml"
  ]
}
```

I also found another small issue for which I'll push a separate PR in a moment with a fix to be merged into this PR, and it could become the next v2.9.0 release.
Let me know whether there's anything else that needs to be done to get this merged!