### PR TITLE
Update regex to include 'All rights reserved.'

### DIFF
--- a/license_tools/header.py
+++ b/license_tools/header.py
@@ -217,7 +217,7 @@ class ParsedHeader:
         else:
             authors_raw = contents
         self.authors = []
-        for match in re.finditer(r" Copyright[^\d]*(?P<from>[0-9]+) *(?:- *(?P<to>[0-9]+))? *(?P<name>[^\n\r]+)", authors_raw, re.IGNORECASE):
+        for match in re.finditer(r" Copyright[^\d]*(?P<from>[0-9]+) *(?:- *(?P<to>[0-9]+))? *(?P<name>[^\n\r]+). All rights reserved.", authors_raw, re.IGNORECASE):
             args = {
                 'name': match.group('name'),
                 'year_from': int(match.group('from'))


### PR DESCRIPTION
Without the extended regex, the `.` from `. All rights` can become part of the extracted `name`, causing the license header to be updated, ultimately leading to header of the form

```
<name>. . . . All rights reserved.
```

This change prevents this. The `.` was not inluded in the regex part `[^\n\r]` because then names such as _John A. Doe_ would not be captured.